### PR TITLE
Java mem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV JAVA_HOME /opt/java
 ENV JAVA_VERSION_MAJOR 8
 ENV JAVA_VERSION_MINOR 91
 ENV JAVA_VERSION_BUILD 14
+ENV JAVA_MAX_MEM 2048m
+ENV JAVA_MIN_MEM 1200m
+ENV EXTRA_JAVA_OPTS ""
 
 RUN yum install -y \
   curl tar \
@@ -43,6 +46,8 @@ ADD content/ /
 
 ## configure nexus runtime env
 RUN sed \
+		-e "s|-Xms1200M|-Xms${JAVA_MIN_MEM}|g" \
+		-e "s|-Xmx1200M|-Xmx${JAVA_MAX_MEM}|g" \
     -e "s|karaf.home=.|karaf.home=/opt/sonatype/nexus|g" \
     -e "s|karaf.base=.|karaf.base=/opt/sonatype/nexus|g" \
     -e "s|karaf.etc=etc|karaf.etc=/opt/sonatype/nexus/etc|g" \
@@ -62,9 +67,5 @@ VOLUME ${NEXUS_DATA}
 EXPOSE 8081 8443
 USER nexus
 WORKDIR /opt/sonatype/nexus
-
-ENV JAVA_MAX_MEM 1200m
-ENV JAVA_MIN_MEM 1200m
-ENV EXTRA_JAVA_OPTS ""
 
 CMD bin/nexus run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sonatype/nexus3
 
+### The actual docker image exists in DTR.  Please be sure you are pulling from there, this
+### Dockerfile only exists here for versioning control, etc.  Changes to the Docker image will
+### be pushed accordingly, and recorded here.
+
 A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 
 To run, binding the exposed port 8081 to the host.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # sonatype/nexus3
 
-### The actual docker image exists in DTR.  Please be sure you are pulling from there, this
-### Dockerfile only exists here for versioning control, etc.  Changes to the Docker image will
-### be pushed accordingly, and recorded here.
+### The actual docker image exists in DTR.  Please be sure you are pulling from there, this Dockerfile only exists here for versioning control, etc.  Changes to the Docker image will be pushed accordingly, and recorded here.
 
 A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 

--- a/content/opt/sonatype/nexus/etc/jetty-https.xml
+++ b/content/opt/sonatype/nexus/etc/jetty-https.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!--
+  ==== HTTPS ====
+  Set the following inside org.sonatype.nexus.cfg:
+  application-port-ssl: the port to listen for https connections
+  -->
+
+  <Ref refid="httpConfig">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort"><Property name="application-port-ssl" /></Set>
+  </Ref>
+
+  <New id="httpsConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Arg><Ref refid="httpConfig"/></Arg>
+    <Call name="addCustomizer">
+      <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
+    </Call>
+  </New>
+
+  <New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+    <Set name="KeyStorePath"><Property name="karaf.etc"/>/ssl/keystore.jks</Set>
+    <Set name="KeyStorePassword">CHANGEME</Set>
+    <Set name="KeyManagerPassword">CHANGEME</Set>
+    <Set name="TrustStorePath"><Property name="karaf.etc"/>/ssl/keystore.jks</Set>
+    <Set name="TrustStorePassword">CHANGEME</Set>
+    <Set name="EndpointIdentificationAlgorithm"></Set>
+    <Set name="NeedClientAuth"><Property name="jetty.ssl.needClientAuth" default="false"/></Set>
+    <Set name="WantClientAuth"><Property name="jetty.ssl.wantClientAuth" default="false"/></Set>
+    <Set name="ExcludeCipherSuites">
+      <Array type="String">
+        <Item>SSL_RSA_WITH_DES_CBC_SHA</Item>
+        <Item>SSL_DHE_RSA_WITH_DES_CBC_SHA</Item>
+        <Item>SSL_DHE_DSS_WITH_DES_CBC_SHA</Item>
+        <Item>SSL_RSA_EXPORT_WITH_RC4_40_MD5</Item>
+        <Item>SSL_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
+        <Item>SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
+        <Item>SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA</Item>
+      </Array>
+    </Set>
+  </New>
+
+  <Call  name="addConnector">
+    <Arg>
+      <New id="httpsConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="acceptors" type="int"><Property name="jetty.https.acceptors" default="-1"/></Arg>
+        <Arg name="selectors" type="int"><Property name="jetty.https.selectors" default="-1"/></Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+            <Item>
+              <New class="org.sonatype.nexus.bootstrap.jetty.InstrumentedConnectionFactory">
+                <Arg>
+                  <New class="org.eclipse.jetty.server.SslConnectionFactory">
+                    <Arg name="next">http/1.1</Arg>
+                    <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                  </New>
+                </Arg>
+              </New>
+            </Item>
+            <Item>
+              <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                <Arg name="config"><Ref refid="httpsConfig" /></Arg>
+              </New>
+            </Item>
+          </Array>
+        </Arg>
+
+        <Set name="host"><Property name="application-host" /></Set>
+        <Set name="port"><Property name="application-port-ssl" /></Set>
+        <Set name="idleTimeout"><Property name="jetty.https.timeout" default="30000"/></Set>
+        <Set name="soLingerTime"><Property name="jetty.https.soLingerTime" default="-1"/></Set>
+        <Set name="acceptorPriorityDelta"><Property name="jetty.https.acceptorPriorityDelta" default="0"/></Set>
+        <Set name="selectorPriorityDelta"><Property name="jetty.https.selectorPriorityDelta" default="0"/></Set>
+        <Set name="acceptQueueSize"><Property name="jetty.https.acceptQueueSize" default="0"/></Set>
+      </New>
+    </Arg>
+  </Call>
+
+</Configure>

--- a/content/opt/sonatype/nexus/etc/ssl/README.md
+++ b/content/opt/sonatype/nexus/etc/ssl/README.md
@@ -1,0 +1,1 @@
+# You need to create a keystore in this directory and call it keystore.jks


### PR DESCRIPTION
Quick hack... requires a new `docker build` to be performed when the value is changed. Yes you can set the `-e JAVA_MAX_MEM=1024m` on `docker run` however, the `sed` magic that updates the nexus.vmoptions is already built in the container so it is a no-op. This could be made better with more time.